### PR TITLE
Update Buildings.json

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -4,6 +4,7 @@
         "uniqueTo": "Nok",
         "cost": -1,
 	"uniques": ["Provides [1] [Terracotta]","Will not be displayed in Civilopedia","Unsellable","Destroyed when the city is captured"],
+	"requiredTech": "Pottery",
 	},
 		{
         "name": "Myrrh",
@@ -11,6 +12,7 @@
         "cost": -1,
 	 "cannotBeBuiltWith": "Frankincense",
 	"uniques": ["Consumes [1] [Incense]","Provides [1] [Myrrh]","Unsellable","Will not be displayed in Civilopedia","Only available <with [Incense]>","Destroyed when the city is captured"],
+	"requiredTech": "Calendar",
 	},
 			{
         "name": "Frankincense",
@@ -18,6 +20,7 @@
         "cost": -1,
 	 "cannotBeBuiltWith": "Myrrh",
 	"uniques": ["Consumes [1] [Incense]","Provides [1] [Frankincense]","Unsellable","Will not be displayed in Civilopedia","Only available <with [Incense]>","Destroyed when the city is captured"],
+	"requiredTech": "Calendar",
 	},
 	{
 		"name": "Ziggurat",


### PR DESCRIPTION
Three buildings didn't have associated techs or costs, and Unciv didn't like that. I've added a "requiredTech" to each of these to fix that; Free Terracotta gets Pottery, obviously, and both Frankincense and Myrrh get Calendar, which is needed to build plantations anyway.