### PR TITLE
Updated per the mod error tool's suggestions

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -55,7 +55,7 @@
 		"maintenance": 4,
 		"culture": 1,
 		"hurryCostModifier": 50,
-		"uniques": ["Remove extra unhappiness from annexed cities","New [Military] units start with [10] Experience [in this city]"],
+		"uniques": ["Removes extra unhappiness from annexed cities","New [Military] units start with [10] XP [in this city]"],
 		"requiredTech": "Construction"
 	},
 	{

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -2,20 +2,20 @@
 	{
         "name": "Free Terracotta",
         "uniqueTo": "Nok",
-        "cost": -1,
+        "cost": 1,
 	"uniques": ["Provides [1] [Terracotta]","Will not be displayed in Civilopedia","Unsellable","Destroyed when the city is captured"],
 	},
 		{
         "name": "Myrrh",
         "uniqueTo": "Himyar",
-        "cost": -1,
+        "cost": 1,
 	 "cannotBeBuiltWith": "Frankincense",
 	"uniques": ["Consumes [1] [Incense]","Provides [1] [Myrrh]","Unsellable","Will not be displayed in Civilopedia","Only available <with [Incense]>","Destroyed when the city is captured"],
 	},
 			{
         "name": "Frankincense",
         "uniqueTo": "Himyar",
-        "cost": -1,
+        "cost": 1,
 	 "cannotBeBuiltWith": "Myrrh",
 	"uniques": ["Consumes [1] [Incense]","Provides [1] [Frankincense]","Unsellable","Will not be displayed in Civilopedia","Only available <with [Incense]>","Destroyed when the city is captured"],
 	},

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -29,7 +29,7 @@
 		"specialistSlots": {"Scientist": 1},
 		"cost":120,
 		"hurryCostModifier": 25,
-		"uniques": ["[+1 Faith] from [River] tiles [in this city]"],
+		"uniques": ["[+1 Faith] from [River] tiles [in this city]","1 Scientist slot"],
 		"requiredBuilding": "Shrine",
 		"requiredTech": "Construction"
 	},

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -29,7 +29,7 @@
 		"specialistSlots": {"Scientist": 1},
 		"cost":120,
 		"hurryCostModifier": 25,
-		"uniques": ["[+1 Faith] from [River] tiles [in this city]","1 Scientist slot"],
+		"uniques": ["[+1 Faith] from [River] tiles [in this city]"],
 		"requiredBuilding": "Shrine",
 		"requiredTech": "Construction"
 	},

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -342,7 +342,7 @@
 		"outerColor": [	94, 50, 0],
 		"uniqueName": "Pyrrhic Victory",
 		"uniqueText": "Can't train Settlers. All military units have + 25% more strength when attacking cities, but suffer -25% penalty when defending against cities. +25% [Production] when constructing military units in capital. Gains a free [Great General] upon researching Bronze Working and Steel",
-		"uniques": ["Cannot build [Settler] units", "[Military] units gain the [Pyrrhic Victory] promotion","[+25]% Production when constructing [Military] units [in capital]","Receive free [Great General] when you discover [Bronze Working]","Receive free [Great General] when you discover [Steel]"],
+		"uniques": ["Cannot build [Settler] units", "[Military] units gain the [Pyrrhic Victory] promotion","[+25]% Production when constructing [Military] units [in capital]","Free [Great General] appears (upon discovering [Bronze Working])","Free [Great General] appears (upon discovering [Steel])"],
 		"cities": ["Ambracia","Phoenike","Passaron"]
 	},
 					{

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -342,7 +342,7 @@
 		"outerColor": [	94, 50, 0],
 		"uniqueName": "Pyrrhic Victory",
 		"uniqueText": "Can't train Settlers. All military units have + 25% more strength when attacking cities, but suffer -25% penalty when defending against cities. +25% [Production] when constructing military units in capital. Gains a free [Great General] upon researching Bronze Working and Steel",
-		"uniques": ["Cannot build [Settler] units", "[Military] units gain the [Pyrrhic Victory] promotion","[+25]% Production when constructing [Military] units [in capital]","Free [Great General] appears (upon discovering [Bronze Working])","Free [Great General] appears (upon discovering [Steel])"],
+		"uniques": ["Cannot build [Settler] units", "[Military] units gain the [Pyrrhic Victory] promotion","[+25]% Production when constructing [Military] units [in capital]","Free [Great General] appears <upon discovering [Bronze Working]>","Free [Great General] appears <upon discovering [Steel]>"],
 		"cities": ["Ambracia","Phoenike","Passaron"]
 	},
 					{

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -342,7 +342,7 @@
 		"outerColor": [	94, 50, 0],
 		"uniqueName": "Pyrrhic Victory",
 		"uniqueText": "Can't train Settlers. All military units have + 25% more strength when attacking cities, but suffer -25% penalty when defending against cities. +25% [Production] when constructing military units in capital. Gains a free [Great General] upon researching Bronze Working and Steel",
-		"uniques": ["Cannot build [Settler] units", "[Military] units gain the [Pyrrhic Victory] promotion","[+25]% Production when constructing [Military] units [in capital]","Free [Great General] appears <upon discovering [Bronze Working]>","Free [Great General] appears <upon discovering [Steel]>"],
+		"uniques": ["Cannot build [Settler] units", "[Military] units gain the [Pyrrhic Victory] promotion","[+25]% Production when constructing [Military] units [in capital]","Free [Great General] appears <upon discovering [Bronze Working] technology>","Free [Great General] appears <upon discovering [Steel] technology>"],
 		"cities": ["Ambracia","Phoenike","Passaron"]
 	},
 					{

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -30,7 +30,7 @@
 		"innerColor": [189, 145, 158],
 		"uniqueName": "Cradle of Civilization",
 		"uniqueText": "All land units move twice as fast on tiles next to rivers. +2 [Science] in Capital",
-		"uniques": ["[+2 Science] [in capital]","[Land] units gain the [Cradle of Civilizations] promotion"],
+		"uniques": ["[+2 Science] [in capital]","[Land] units gain the [Cradle of Civilizations] promotion", "Civilization is available until the [Medieval era]"],
 		"cities": ["Uruk","Eridu","Kish","Lagash","Nibru","Ur","Bad-Tibira","Zimbir","Shuruppak","Umma",
 			"Larsa","Isin","Girsu","Adab","Larak","Abu Salabikh","Akshak","Hamazi","Nina","Kutha",
 			"Marad","Zabalam","Kisurra","Pazurish-Dagan","Kutallu","Kesh","Apisada","Kisiga","Enegi","Ki-an",

--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -63,8 +63,8 @@
 		"afterPeace": "Praise the Lord as he gives peace!",
 		"tradeRequest": "I present you this trade offer.",
 
-		"outerColor": [	255, 255, 204],
-		"innerColor": [	51, 153, 255],
+		"outerColor": [	255, 255, 206],
+		"innerColor": [	49, 146, 243],
 		"uniqueName": "Promised Land",
 		"uniques": ["[+1 Food, +1 Faith] from every [Pasture]","[+1 Faith] per [4] population [in all cities]"],
 		"cities": ["Jerusalem","Hebron","Gaza","Jericho","Bethlehem","Nazareth","Meggido","Beer-Sheba","Judah",
@@ -172,7 +172,7 @@
 		"outerColor": [	128, 9, 46],
 		"innerColor": [	204, 170, 118],
 		"uniqueName": "Sacred Mountains", 
-		"uniques": ["Double quantity of [Horses] produced","[Mounted] units gain the [Ignore terrain cost] promotion","[+1 Food, +1 Culture, +1 Production] from every [Mountain]"],
+		"uniques": ["[+100]% [Horses] resource production","[Mounted] units gain the [Ignore terrain cost] promotion","[+1 Food, +1 Culture, +1 Production] from every [Mountain]"],
 		"cities": ["Yerevan","Tigranakert","Artashat","Yervandashat","Armavir","Gyumri","Vanadzor","Abovyan","Kapan","Ararat","Gavar",
 		"Hrazdan","Ijevan","Goris","Ashtarak","Masis"]
 	}
@@ -203,8 +203,8 @@
 		"afterPeace": "We shall now pray for the better, I mean more profitable, days!",
 		"tradeRequest": "I bring you an excellent offer!",
 
-		"outerColor": [	84, 215, 247],
-		"innerColor": [	255, 255, 255],
+		"outerColor": [63, 155, 177],
+		"innerColor": [255, 255, 255],
 		"uniqueName": "Shackles of Gold",
 		"uniqueText": "Earns [Gold] for killing enemy land units", 
 		"uniques": ["Earn [75]% of killed [Land] unit's [Strength] as [Gold]"],
@@ -238,8 +238,8 @@
 		"afterPeace": "What such bloodhirsty beast might want?",
 		"tradeRequest": "What do you think?",
 
-		"outerColor": [	91, 176, 156],
-		"innerColor": [ 40, 94, 68],
+		"outerColor": [99, 179, 160],
+		"innerColor": [38, 90, 65],
 		"uniqueName": "Feathered Serpent",
 		"uniqueText": "May buy National Wonders with [Faith].",
 		"uniques": ["May buy [National Wonder] buildings with [Faith] for [1] times their normal Production cost"],
@@ -309,7 +309,7 @@
 		"outerColor": [	31, 31, 31],
 		"innerColor": [	247, 198, 0],
 		"uniqueName": "Desert Paradise",
-		"uniques": ["Double quantity of [Incense] produced","May convert Incense to Myrrh or Frankincense luxury resources","[+15]% Strength <within [1] tiles of a [Desert]>"],
+		"uniques": ["[+100]% [Incense] resource production","May convert Incense to Myrrh or Frankincense luxury resources","[+15]% Strength <within [1] tiles of a [Desert]>"],
 		"cities": ["Zafar","Sana'a","Ma'rib","Najran","Mocha","Haram","Haywan","Mukhwan","Yabrin","Shabwa","Wa'lan","Libna","Nashaq","Timna","Sirwah","Quarnawu","Kaminahu","Baraqish"]
 	},
 				{

--- a/jsons/Techs.json
+++ b/jsons/Techs.json
@@ -1,0 +1,21 @@
+[
+    {
+		"columnNumber": 17,
+		"era": "Future era",
+		"techCost": 9500,
+		"buildingCost": 750,
+		"wonderCost": 1250,
+		"techs": [
+			{
+				"name": "Future Tech",
+				"row": 5,
+				"prerequisites": ["Globalization","Particle Physics","Nuclear Fusion","Nanotechnology","Stealth"],
+				"uniques": ["Can be continually researched","Gain [1000]-[2000] [Culture]","Gain [1000] [Gold]", "[+200 Production]","[+100]% [Science]","[100] Unit Supply",
+          "[+100]% Strength for cities","Provides [100] [Uranium]","[+100]% [Strategic] resource production","[+100]% spy effectiveness [in all cities]",
+          "[+100]% XP gained from combat",],
+				"quote": "'I think we agree, the past is over.' - George W. Bush",
+                "civilopediaText": [{"text": "Who knows what the future holds?"}]
+			}
+		]
+	}
+]

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -147,7 +147,7 @@
 		"upgradesTo": "Crossbowman",
 		"obsoleteTech": "Machinery",
 		"promotions": ["Mobility"],
-		"uniques": ["Consumes [1] [Horses]","Can move after attacking","[-25]% Strength <vs cities> <when attacking>", "No defensive terrain bonus","May withdraw before melee ([50]%)"],
+		"uniques": ["Consumes [1] [Horses]","Can move after attacking","[-25]% Strength <vs cities> <when attacking>", "No defensive terrain bonus","Withdraws before melee combat (with [50]% chance)"],
 		"attackSound": "arrow"
 	},
 		{	

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -147,7 +147,7 @@
 		"upgradesTo": "Crossbowman",
 		"obsoleteTech": "Machinery",
 		"promotions": ["Mobility"],
-		"uniques": ["Consumes [1] [Horses]","Can move after attacking","[-25]% Strength <vs cities> <when attacking>", "No defensive terrain bonus","Withdraws before melee combat (with [50]% chance)"],
+		"uniques": ["Consumes [1] [Horses]","Can move after attacking","[-25]% Strength <vs cities> <when attacking>", "No defensive terrain bonus","Withdraws before melee combat <with [50]% chance>"],
 		"attackSound": "arrow"
 	},
 		{	


### PR DESCRIPTION
Ancient Civilizations: (Building) Sphinx Gate's unique "Remove extra unhappiness from annexed cities" is deprecated As of 4.16.14, replace with "Removes extra unhappiness from annexed cities"
Ancient Civilizations: (Building) Sphinx Gate's unique "New [Military] units start with [10] Experience [in this city]" is deprecated As of 4.15.11, replace with "New [Military] units start with [10] XP [in this city]"
Israel's colors do not contrast enough - it is unreadable!
Suggested colors: 
		"outerColor": [255, 255, 206],
		"innerColor": [49, 146, 243],
Ancient Civilizations: (Nation) Armenia's unique "Double quantity of [Horses] produced" is deprecated As of 4.16.18, replace with "[+100]% [Horses] resource production"
Macrobia's colors do not contrast enough - it is unreadable!
Suggested colors: 
		"outerColor": [63, 155, 177],
		"innerColor": [255, 255, 255],
The Olmec's colors do not contrast enough - it is unreadable!
Suggested colors: 
		"outerColor": [99, 179, 160],
		"innerColor": [38, 90, 65],
Ancient Civilizations: (Nation) Himyar's unique "Double quantity of [Incense] produced" is deprecated As of 4.16.18, replace with "[+100]% [Incense] resource production"